### PR TITLE
fixed a bug that Prefork server does not end at SIGTERM.

### DIFF
--- a/lib/MojoX/Log/Dispatch/Simple.pm
+++ b/lib/MojoX/Log/Dispatch/Simple.pm
@@ -31,7 +31,6 @@ sub new {
 
 sub _log {
     shift->emit( 'message', @_ );
-    return;
 }
 
 {


### PR DESCRIPTION
Hi.

I fixed a bug that Prefork server does not end at SIGTERM.

Mojo::Log::debug appears to have been expected to return a value.
MojoX::Log::Dispatch::Simple::debug and it will be the same behavior.

Places where the return value of $log->debug(...) is expected will be below.
Mojolicious-6.12
https://github.com/kraih/mojo/blob/277ac26822993cb427f9633bf7900734be4ad53f/lib/Mojo/Server/Prefork.pm#L134

https://github.com/gryphonshafer/MojoX-Log-Dispatch-Simple/blob/a824c5128fe26365f7a5d99eec31129561c23c79/lib/MojoX/Log/Dispatch/Simple.pm#L34
If undef is returned above, it looks like the below.

<pre>
# hypnotoad -f myapp
Listening at "http://127.0.0.1:3000"
Server available at http://127.0.0.1:3000
Manager 78972 started
Worker 78973 started
Creating process id file "/var/run/myapp.pid"
Worker 78974 started
    ( kill 78972 in the other terminal )
Stopping worker 78974
Stopping worker 78973
Stopping worker 78974
Stopping worker 78973
Stopping worker 78974
Stopping worker 78973
... snip ...
</pre>


If there is no problem, please merge.

Cheers
Tomohiro Hosaka
